### PR TITLE
process more than one system separeted by commas

### DIFF
--- a/bin/hascheevos.sh
+++ b/bin/hascheevos.sh
@@ -52,11 +52,12 @@ CONSOLE_NAME[11]=mastersystem
 #CONSOLE_NAME[13]=atari
 #CONSOLE_NAME[14]=neogeo
 
-# RetroPie specific variables, used only when invoked with --scrape
+# RetroPie specific variables
 readonly RP_ROMS_DIR="$HOME/RetroPie/roms"
+readonly VALID_SYSTEMS=megadrive|n64|snes|gb|gba|gbc|nes|pcengine|mastersystem
 GAMELIST=
 GAMELIST_BAK=
-ROMS_DIR=
+ROMS_DIR=()
 SCRAPE_FLAG=0
 
 
@@ -728,13 +729,17 @@ while [[ -n "$1" ]]; do
 
             check_argument "$1" "$2" || safe_exit 1
             shift
-            ROMS_DIR="$RP_ROMS_DIR/$1"
 
-            # TODO: make it able to process more than one systems separeted by commas
-            if [[ ! -d "$ROMS_DIR" ]]; then
-                echo "ERROR: \"$(basename "$ROMS_DIR")\": invalid system." >&2
-                safe_exit 1
-            fi
+            oldIFS="$IFS"
+            IFS=,
+            for i in $1; do
+                if ! [[ -d "$RP_ROMS_DIR/$i" || "$i" =~ ^($VALID_SYSTEMS)$ ]]; then
+                    echo "WARNING: ignoring \"$i\": invalid system." >&2
+                    continue
+                fi
+                ROMS_DIR+=("$RP_ROMS_DIR/$i")
+            done
+            IFS="$oldIFS"
             ;;
 
         *)  break
@@ -745,10 +750,10 @@ done
 
 update_hash_libraries
 
-if is_retropie && [[ -d "$ROMS_DIR" ]]; then
+if is_retropie && [[ -n "$ROMS_DIR" ]]; then
     while read -r i; do
         process_files "$i"
-    done < <(find "$ROMS_DIR" -type f -regextype egrep -iregex ".*\.($EXTENSIONS)$")
+    done < <(find "${ROMS_DIR[@]}" -type f -regextype egrep -iregex ".*\.($EXTENSIONS)$")
 fi
 
 process_files "$@"


### PR DESCRIPTION
improving the `--system` option (RetroPie only).